### PR TITLE
Consider all enabled spell book tabs

### DIFF
--- a/LibSpellRange-1.0.lua
+++ b/LibSpellRange-1.0.lua
@@ -76,12 +76,12 @@ local spellsByID_pet = Lib.spellsByID_pet
 
 -- Updates spellsByName and spellsByID
 local function UpdateBook(bookType)
-	local _, _, offs, numspells = GetSpellTabInfo(3)
-	local max = offs -- The offset of the next tab is the max ID of the previous tab.
-	if numspells == 0 then
-		-- New characters pre level 10 only have 2 tabs.
-		local _, _, offs, numspells = GetSpellTabInfo(2)
-		max = offs + numspells 
+	local max = 0
+	for i = 1, GetNumSpellTabs() do
+		local _, _, offs, numspells, _, specId = GetSpellTabInfo(i)
+		if specId == 0 then
+			max = offs + numspells
+		end
 	end
 
 	local spellsByName = Lib["spellsByName_" .. bookType]


### PR DESCRIPTION
Don't hardcode the number of spell tabs, but instead iterate over all
spell tabs and check the spec id for each tab.