### PR TITLE
Fix issue on classic with lower ranks + spellbook don't show all ranks

### DIFF
--- a/LibSpellRange-1.0.lua
+++ b/LibSpellRange-1.0.lua
@@ -10,7 +10,7 @@
 -- @name LibSpellRange-1.0.lua
 
 local major = "SpellRange-1.0"
-local minor = 21
+local minor = 22
 
 assert(LibStub, format("%s requires LibStub.", major))
 
@@ -269,6 +269,8 @@ function Lib.IsSpellInRange(spellInput, unit)
 		end
 		if isTWWSpellInRange then
 			return IsSpellInRange(spellInput, unit)
+		else
+			return IsSpellInRange(GetSpellInfo(spellInput), unit)
 		end
 	else
 		local spellInput = strlowerCache[spellInput]
@@ -324,6 +326,8 @@ function Lib.SpellHasRange(spellInput)
 		end
 		if isTWWSpellHasRange then
 			return SpellHasRange(spellInput)
+		else
+			return SpellHasRange(GetSpellInfo(spellInput))
 		end
 	else
 		local spellInput = strlowerCache[spellInput]


### PR DESCRIPTION
Make IsSpellInRange work on classic with lower ranks when all ranks a…re not shown on spellbook

IsSpellBookItemInRange return nil if the option to show all ranks in spellbook is not ticked and we test a lower rank Workaround this issue by testing by name when no result was found using spellbook

![image](https://github.com/user-attachments/assets/7529806d-6a75-479c-8be6-7b2a65902b4c)
